### PR TITLE
Flatpak Binary Helpers

### DIFF
--- a/flatpak/org.opencpn.OpenCPN.yaml
+++ b/flatpak/org.opencpn.OpenCPN.yaml
@@ -30,7 +30,7 @@ finish-args:
 add-extensions:
     org.opencpn.OpenCPN.Plugin:
         directory: extensions
-        merge-dirs: lib/opencpn;share/opencpn/plugins;share/locale
+        merge-dirs: lib/opencpn;share/opencpn/plugins;share/locale;bin
         subdirectories: true
         no-autodownload: true
         autodelete: false


### PR DESCRIPTION
Adding ;bin to the end of the merge-dirs line means that links are automatically created allowing plugins to find their binary helpers. See for example oesENC where I created this issue https://github.com/bdbcat/oesenc_pi/issues/92#issuecomment-636581041.
I accept that there may be other ways to solve this problem, but this does seem to work OK. With this small change in place I made a flatpak for oernc that also behaves properly.
Greg